### PR TITLE
rename cast functions to narrow and add `narrowCast` function

### DIFF
--- a/src/functions/misc.ts
+++ b/src/functions/misc.ts
@@ -9,7 +9,7 @@ import { AnyKey } from 'tsdef'
 
 /**
  * a function to be used when you need to provide a type in a value position. currently this is only supposed to be used
- * by {@link cast} but there may be other use cases for it.
+ * by {@link narrow} but there may be other use cases for it.
  *
  * you should not call this function, since you can specify the generic without calling it.
  * @example
@@ -23,13 +23,14 @@ export const as = <T>(_dontCallThisFunction: never): T => {
 
 /**
  * narrows the given value from type `Base` to type `Narrowed` without having to assign it to a new variable
+ *
  * due to limitations in generics and assertion functions, you have to provide the type using the {@link as} function.
  * @example
  * declare const foo: number
  * cast(foo, as<1 | 2>)
  * type Bar = typeof foo //1|2
  */
-export const cast: <_ extends OnlyInfer, Base, Narrowed extends Base>(
+export const narrow: <_ extends OnlyInfer, Base, Narrowed extends Base>(
     value: Base,
     type: typeof as<Narrowed>,
 ) => asserts value is Narrowed = (_value, _type) => {
@@ -37,7 +38,7 @@ export const cast: <_ extends OnlyInfer, Base, Narrowed extends Base>(
 }
 
 /**
- * unsafely casts the given value to type `T` without having to assign it to a new variable.
+ * unsafely narrows the given value to type `T` without having to assign it to a new variable.
  *
  * because of how assertion functions work, the type will narrow to `never` if the types don't overlap
  * @example
@@ -51,9 +52,26 @@ export const cast: <_ extends OnlyInfer, Base, Narrowed extends Base>(
  * unsafeCast<1|2>(foo)
  * type Bar = typeof foo //never
  */
-export const unsafeCast: <T>(_value: unknown) => asserts _value is T = (_value) => {
+export const unsafeNarrow: <T>(_value: unknown) => asserts _value is T = (_value) => {
     // do nothing
 }
+
+/**
+ * casts the given value from type `Original` to an itersection of `Original & Casted` (like type predicates & type assertions do),
+ * but instead of changing the type of the original variable, it returns a value with the new type (like regular type casting does).
+ *
+ * due to limitations in generics and assertion functions, you have to provide the type using the {@link as} function.
+ *
+ * because of how assertion functions work, the type will narrow to `never` if the types don't overlap
+ * @example
+ * declare const foo: number
+ * cast(foo, as<1 | 2>)
+ * type Bar = typeof foo //1|2
+ */
+export const narrowCast = <_ extends OnlyInfer, Original, Casted>(
+    value: Original,
+    _type: typeof as<Casted>,
+): Original & Casted => value as Original & Casted
 
 /**
  * converts the given `value` to a string, preserving its value at compiletime where possible

--- a/test/functions/misc.spec.ts
+++ b/test/functions/misc.spec.ts
@@ -1,14 +1,15 @@
 import {
     New,
     as,
-    cast,
     dontNarrow,
     entries,
     exactly,
     hasPropertyPredicate,
     isNullOrUndefined,
+    narrow,
+    narrowCast,
     runUntil,
-    unsafeCast,
+    unsafeNarrow,
 } from '../../src/functions/misc'
 import { NonNullish } from '../../src/types/misc'
 import { PowerAssert } from 'typed-nodejs-assert'
@@ -459,15 +460,15 @@ describe('exactly', () => {
     })
 })
 
-describe('cast', () => {
+describe('narrow', () => {
     test('success', () => {
         const foo = 1 as number
-        cast(foo, as<1 | 2>)
+        narrow(foo, as<1 | 2>)
         exactly<1 | 2>()(foo)
     })
     test('fail', () => {
         const foo = '' as string
-        cast(
+        narrow(
             foo,
             // @ts-expect-error negative test
             as<1 | 2>,
@@ -476,16 +477,29 @@ describe('cast', () => {
     })
 })
 
-describe('unsafeCast', () => {
+describe('unsafeNarrow', () => {
     test('safe', () => {
         const foo = 1 as number
-        unsafeCast<1 | 2>(foo)
+        unsafeNarrow<1 | 2>(foo)
         exactly<1 | 2>()(foo)
     })
     test('unsafe', () => {
         const foo = '' as string
-        unsafeCast<1 | 2>(foo)
+        unsafeNarrow<1 | 2>(foo)
         exactly<never>()(foo)
+    })
+})
+
+describe('narrowCast', () => {
+    test('safe', () => {
+        const foo = 1 as number | string
+        const bar = narrowCast(foo, as<number | boolean>)
+        exactly<number>()(bar)
+    })
+    test('unsafe', () => {
+        const foo = 1 as number | string
+        const bar = narrowCast(foo, as<boolean>)
+        exactly<never>()(bar)
     })
 })
 


### PR DESCRIPTION
there are several types of casting: 
||modifies original variable's type|returns the value with the casted type|intersects original type with casted type|allows non-overlapping types|
|-|-|-|-|-|
`as` keyword||yes|||
`narrow` function|yes||yes|
`unsafeNarrow` function|yes||yes|yes
`narrowCast` function||yes|yes|yes